### PR TITLE
feat: initialize Expo mobile app

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,1 @@
+BASE_URL=https://api.example.com

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.expo
+.expo-shared
+*.log

--- a/apps/mobile/.prettierrc
+++ b/apps/mobile/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { StatusBar } from 'expo-status-bar';
+import RootNavigator from './src/navigation';
+import { AuthProvider } from './src/store/auth';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <StatusBar style="auto" />
+      <RootNavigator />
+    </AuthProvider>
+  );
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['inline-dotenv'],
+  };
+};

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -1,0 +1,15 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import ts from 'typescript-eslint';
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+});
+
+export default [
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...compat.config({
+    extends: ['prettier'],
+  }),
+];

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "mobile",
+  "version": "1.0.0",
+  "private": true,
+  "main": "expo/AppEntry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "lint": "eslint .",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "axios": "^1.4.0",
+    "expo": "~49.0.0",
+    "expo-checkbox": "~2.3.0",
+    "expo-localization": "~14.1.0",
+    "expo-status-bar": "~1.6.0",
+    "i18n-js": "^4.4.0",
+    "react": "18.2.0",
+    "react-hook-form": "^7.45.1",
+    "react-native": "0.72.3",
+    "react-native-gesture-handler": "~2.12.0",
+    "react-native-safe-area-context": "4.5.0",
+    "react-native-screens": "~3.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "~18.2.0",
+    "@types/react-native": "~0.72.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "babel-plugin-inline-dotenv": "^3.0.1",
+    "eslint": "^8.45.0",
+    "eslint-config-prettier": "^8.8.0",
+    "prettier": "^2.8.8",
+    "typescript": "^5.1.3",
+    "@eslint/js": "^9.0.0",
+    "@eslint/eslintrc": "^3.0.0",
+    "typescript-eslint": "^6.0.0"
+  }
+}

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: process.env.BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  name: string;
+  email: string;
+  password: string;
+}

--- a/apps/mobile/src/components/FormInput.tsx
+++ b/apps/mobile/src/components/FormInput.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, TextInput, Text, StyleSheet } from 'react-native';
+import { Controller, Control } from 'react-hook-form';
+
+interface Props {
+  name: string;
+  control: Control<any>;
+  rules?: any;
+  placeholder?: string;
+  secureTextEntry?: boolean;
+}
+
+export default function FormInput({
+  name,
+  control,
+  rules,
+  placeholder,
+  secureTextEntry,
+}: Props) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+        <View style={styles.container}>
+          <TextInput
+            style={[styles.input, error && styles.errorBorder]}
+            onBlur={onBlur}
+            onChangeText={onChange}
+            value={value}
+            placeholder={placeholder}
+            secureTextEntry={secureTextEntry}
+          />
+          {error && <Text style={styles.errorText}>{error.message || 'Error'}</Text>}
+        </View>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { width: '100%', marginBottom: 12 },
+  input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 4, padding: 8 },
+  errorBorder: { borderColor: 'red' },
+  errorText: { color: 'red', marginTop: 4 },
+});

--- a/apps/mobile/src/i18n.ts
+++ b/apps/mobile/src/i18n.ts
@@ -1,0 +1,56 @@
+import * as Localization from 'expo-localization';
+import i18n from 'i18n-js';
+
+i18n.translations = {
+  en: {
+    onboarding: {
+      title: 'Welcome',
+      acceptTerms: 'I accept the Terms of Service',
+      over18: 'I am over 18 years old',
+      continue: 'Continue',
+    },
+    login: {
+      title: 'Login',
+      email: 'Email',
+      password: 'Password',
+      submit: 'Login',
+      register: 'Register',
+    },
+    register: {
+      title: 'Register',
+      name: 'Name',
+      email: 'Email',
+      password: 'Password',
+      submit: 'Create account',
+      login: 'Back to login',
+    },
+  },
+  es: {
+    onboarding: {
+      title: 'Bienvenido',
+      acceptTerms: 'Acepto los Términos de Servicio',
+      over18: 'Soy mayor de 18 años',
+      continue: 'Continuar',
+    },
+    login: {
+      title: 'Iniciar sesión',
+      email: 'Correo',
+      password: 'Contraseña',
+      submit: 'Entrar',
+      register: 'Registrarse',
+    },
+    register: {
+      title: 'Registro',
+      name: 'Nombre',
+      email: 'Correo',
+      password: 'Contraseña',
+      submit: 'Crear cuenta',
+      login: 'Volver a login',
+    },
+  },
+};
+
+i18n.locale = Localization.locale.split('-')[0];
+i18n.fallbacks = true;
+
+export default i18n;

--- a/apps/mobile/src/navigation/index.tsx
+++ b/apps/mobile/src/navigation/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import OnboardingScreen from '../screens/OnboardingScreen';
+import LoginScreen from '../screens/LoginScreen';
+import RegisterScreen from '../screens/RegisterScreen';
+import { useColorScheme } from 'react-native';
+import { getTheme } from '../theme';
+
+export type RootStackParamList = {
+  Onboarding: undefined;
+  Login: undefined;
+  Register: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootNavigator() {
+  const scheme = useColorScheme();
+  return (
+    <NavigationContainer theme={getTheme(scheme)}>
+      <Stack.Navigator initialRouteName="Onboarding">
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} options={{ headerShown: false }} />
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Register" component={RegisterScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { useForm } from 'react-hook-form';
+import i18n from '../i18n';
+import FormInput from '../components/FormInput';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation';
+import { useAuth } from '../store/auth';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Login'>;
+
+interface FormValues {
+  email: string;
+  password: string;
+}
+
+export default function LoginScreen({ navigation }: Props) {
+  const { control, handleSubmit } = useForm<FormValues>();
+  const { login } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (data: FormValues) => {
+    try {
+      setLoading(true);
+      setError(null);
+      await login(data.email, data.password);
+    } catch (e) {
+      setError('Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{i18n.t('login.title')}</Text>
+      <FormInput
+        name="email"
+        control={control}
+        placeholder={i18n.t('login.email')}
+        rules={{ required: 'Email required' }}
+      />
+      <FormInput
+        name="password"
+        control={control}
+        placeholder={i18n.t('login.password')}
+        secureTextEntry
+        rules={{ required: 'Password required' }}
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+      {loading ? (
+        <ActivityIndicator />
+      ) : (
+        <Button title={i18n.t('login.submit')} onPress={handleSubmit(onSubmit)} />
+      )}
+      <Button title={i18n.t('login.register')} onPress={() => navigation.navigate('Register')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  title: { fontSize: 24, marginBottom: 24, textAlign: 'center' },
+  error: { color: 'red', marginBottom: 12, textAlign: 'center' },
+});

--- a/apps/mobile/src/screens/OnboardingScreen.tsx
+++ b/apps/mobile/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import Checkbox from 'expo-checkbox';
+import i18n from '../i18n';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
+
+export default function OnboardingScreen({ navigation }: Props) {
+  const [accepted, setAccepted] = useState(false);
+  const [adult, setAdult] = useState(false);
+
+  const canContinue = accepted && adult;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{i18n.t('onboarding.title')}</Text>
+      <View style={styles.row}>
+        <Checkbox value={accepted} onValueChange={setAccepted} />
+        <Text style={styles.text}>{i18n.t('onboarding.acceptTerms')}</Text>
+      </View>
+      <View style={styles.row}>
+        <Checkbox value={adult} onValueChange={setAdult} />
+        <Text style={styles.text}>{i18n.t('onboarding.over18')}</Text>
+      </View>
+      <Button
+        title={i18n.t('onboarding.continue')}
+        onPress={() => navigation.replace('Login')}
+        disabled={!canContinue}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  row: { flexDirection: 'row', alignItems: 'center', marginBottom: 12 },
+  text: { marginLeft: 8 },
+  title: { fontSize: 24, marginBottom: 24, textAlign: 'center' },
+});

--- a/apps/mobile/src/screens/RegisterScreen.tsx
+++ b/apps/mobile/src/screens/RegisterScreen.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import { useForm } from 'react-hook-form';
+import i18n from '../i18n';
+import FormInput from '../components/FormInput';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation';
+import { useAuth } from '../store/auth';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Register'>;
+
+interface FormValues {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export default function RegisterScreen({ navigation }: Props) {
+  const { control, handleSubmit } = useForm<FormValues>();
+  const { register: registerUser } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (data: FormValues) => {
+    try {
+      setLoading(true);
+      setError(null);
+      await registerUser(data.name, data.email, data.password);
+      navigation.navigate('Login');
+    } catch (e) {
+      setError('Register failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{i18n.t('register.title')}</Text>
+      <FormInput
+        name="name"
+        control={control}
+        placeholder={i18n.t('register.name')}
+        rules={{ required: 'Name required' }}
+      />
+      <FormInput
+        name="email"
+        control={control}
+        placeholder={i18n.t('register.email')}
+        rules={{ required: 'Email required' }}
+      />
+      <FormInput
+        name="password"
+        control={control}
+        placeholder={i18n.t('register.password')}
+        secureTextEntry
+        rules={{ required: 'Password required' }}
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+      {loading ? (
+        <ActivityIndicator />
+      ) : (
+        <Button title={i18n.t('register.submit')} onPress={handleSubmit(onSubmit)} />
+      )}
+      <Button title={i18n.t('register.login')} onPress={() => navigation.navigate('Login')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  title: { fontSize: 24, marginBottom: 24, textAlign: 'center' },
+  error: { color: 'red', marginBottom: 12, textAlign: 'center' },
+});

--- a/apps/mobile/src/store/auth.tsx
+++ b/apps/mobile/src/store/auth.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState } from 'react';
+import { apiClient, LoginRequest, RegisterRequest } from '../api/client';
+
+interface AuthContextProps {
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  user: any;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  login: async () => {},
+  register: async () => {},
+  user: null,
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  const login = async (email: string, password: string) => {
+    const payload: LoginRequest = { email, password };
+    const response = await apiClient.post('/auth/login', payload);
+    setUser(response.data);
+  };
+
+  const register = async (name: string, email: string, password: string) => {
+    const payload: RegisterRequest = { name, email, password };
+    await apiClient.post('/auth/register', payload);
+  };
+
+  return (
+    <AuthContext.Provider value={{ login, register, user }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/apps/mobile/src/theme/index.ts
+++ b/apps/mobile/src/theme/index.ts
@@ -1,0 +1,23 @@
+import { DarkTheme as NavigationDarkTheme, DefaultTheme as NavigationDefaultTheme, Theme } from '@react-navigation/native';
+import { ColorSchemeName } from 'react-native';
+
+export const LightTheme: Theme = {
+  ...NavigationDefaultTheme,
+  colors: {
+    ...NavigationDefaultTheme.colors,
+    background: '#ffffff',
+    text: '#000000',
+  },
+};
+
+export const DarkTheme: Theme = {
+  ...NavigationDarkTheme,
+  colors: {
+    ...NavigationDarkTheme.colors,
+    background: '#000000',
+    text: '#ffffff',
+  },
+};
+
+export const getTheme = (scheme: ColorSchemeName | null): Theme =>
+  scheme === 'dark' ? DarkTheme : LightTheme;

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "jsx": "react"
+  },
+  "include": ["src", "App.tsx"]
+}


### PR DESCRIPTION
## Summary
- scaffold Expo/TypeScript mobile app
- add onboarding, login and register screens with navigation
- setup theming, i18n, axios client and auth context

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_689a61d073008323946cecb75c8e9917