### PR TITLE
feat: add profiles module

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -8,6 +8,7 @@ import { Message } from './entities/message.entity';
 import { AdImpression } from './entities/ad-impression.entity';
 import { RetentionModule } from './retention/retention.module';
 import { AuthModule } from './auth/auth.module';
+import { ProfilesModule } from './profiles/profiles.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { AuthModule } from './auth/auth.module';
     HealthModule,
     RetentionModule,
     AuthModule,
+    ProfilesModule,
   ],
 })
 export class AppModule {}

--- a/apps/server/src/profiles/dto/update-profile.dto.ts
+++ b/apps/server/src/profiles/dto/update-profile.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  IsUrl,
+} from 'class-validator';
+
+export class UpdateProfileDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @ApiProperty({ required: false, maxLength: 160 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(160)
+  bio?: string;
+
+  @ApiProperty({ required: false, minimum: 18, maximum: 120 })
+  @IsOptional()
+  @IsInt()
+  @Min(18)
+  @Max(120)
+  age?: number;
+
+  @ApiProperty({ required: false, type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  interests?: string[];
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  country?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  language?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsUrl()
+  avatar_url?: string;
+}

--- a/apps/server/src/profiles/profiles.controller.ts
+++ b/apps/server/src/profiles/profiles.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ProfilesService } from './profiles.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+interface JwtRequest extends Request {
+  user: { sub: string; email: string };
+}
+
+@ApiTags('profiles')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('profiles')
+export class ProfilesController {
+  constructor(private readonly profiles: ProfilesService) {}
+
+  @Get('me')
+  getMe(@Req() req: JwtRequest) {
+    return this.profiles.getMe(req.user.sub);
+  }
+
+  @Patch('me')
+  updateMe(@Req() req: JwtRequest, @Body() dto: UpdateProfileDto) {
+    return this.profiles.updateMe(req.user.sub, dto);
+  }
+}

--- a/apps/server/src/profiles/profiles.module.ts
+++ b/apps/server/src/profiles/profiles.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Profile } from '../entities/profile.entity';
+import { ProfilesController } from './profiles.controller';
+import { ProfilesService } from './profiles.service';
+import { ProfilesRepository } from './profiles.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Profile])],
+  controllers: [ProfilesController],
+  providers: [ProfilesService, ProfilesRepository],
+})
+export class ProfilesModule {}

--- a/apps/server/src/profiles/profiles.repository.ts
+++ b/apps/server/src/profiles/profiles.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Profile } from '../entities/profile.entity';
+
+@Injectable()
+export class ProfilesRepository extends Repository<Profile> {
+  constructor(private readonly dataSource: DataSource) {
+    super(Profile, dataSource.createEntityManager());
+  }
+
+  findByUserId(userId: string) {
+    return this.findOne({ where: { user_id: userId } });
+  }
+
+  findByNickname(nickname: string) {
+    return this.findOne({ where: { nickname } });
+  }
+}

--- a/apps/server/src/profiles/profiles.service.ts
+++ b/apps/server/src/profiles/profiles.service.ts
@@ -1,0 +1,31 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { Profile } from '../entities/profile.entity';
+import { ProfilesRepository } from './profiles.repository';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Injectable()
+export class ProfilesService {
+  constructor(private readonly profiles: ProfilesRepository) {}
+
+  async getMe(userId: string): Promise<Profile> {
+    const profile = await this.profiles.findByUserId(userId);
+    if (!profile) {
+      throw new NotFoundException('Profile not found');
+    }
+    return profile;
+  }
+
+  async updateMe(userId: string, dto: UpdateProfileDto): Promise<Profile> {
+    const profile = await this.getMe(userId);
+
+    if (dto.nickname) {
+      const existing = await this.profiles.findByNickname(dto.nickname);
+      if (existing && existing.user_id !== userId) {
+        throw new ConflictException('Nickname already taken');
+      }
+    }
+
+    Object.assign(profile, dto);
+    return this.profiles.save(profile);
+  }
+}


### PR DESCRIPTION
## Summary
- add profile module with GET/PATCH endpoints for current user
- validate nickname uniqueness, bio length, age, and interests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a66c59b7c832382398e6a38e0d809